### PR TITLE
Add utils roundtrip test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,6 @@ dev = [
     "pip>=25.1.1",
     "pytest>=8.3.5",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import os
+from tempfile import TemporaryDirectory
+
+from src.core import Story, Student, StoryCondition
+from src.utils import serialize, deserialize
+
+
+def test_serialize_deserialize_roundtrip():
+    story = Story(
+        scenario_id="test-id",
+        student=Student(interests="reading", age=10),
+        condition=StoryCondition(situation="needs encouragement"),
+    )
+
+    with TemporaryDirectory() as tmpdir:
+        file_path = os.path.join(tmpdir, "story.json")
+        serialize(story, file_path)
+        loaded = deserialize(file_path, Story)
+        assert loaded == story
+


### PR DESCRIPTION
## Summary
- add a basic test for utils.serialize/deserialize
- configure pytest to look in `tests`

## Testing
- `pytest -vv tests/test_utils.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_6843289cd94483339602852b08dbc119