### PR TITLE
Fix union type in assertion

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -126,7 +126,7 @@ def get_student_info(scenario_id: str | None = typer.Argument(None)):
         )
 
         assert isinstance(responses["situation"], str)
-        assert isinstance(responses["guidance"], str | None)
+        assert responses["guidance"] is None or isinstance(responses["guidance"], str)
         guidance = None if not responses["guidance"] else responses["guidance"]
         story_condition = StoryCondition(
             situation=responses["situation"],


### PR DESCRIPTION
## Summary
- fix union type check in CLI's assertion

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684328867ef08333acdaff0201f61634