### PR TITLE
Add FastAPI story creation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ uv pip install .
 uv run cli.py
 ```
 
+### API Server
+
+An HTTP API is also available to programmatically create stories.
+
+```bash
+uvicorn src.api:app --reload
+```
+
 ## Target Audience
 
 - **Special Education Teachers**: Primary users who create stories for their students

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,12 +14,14 @@ dependencies = [
     "tenacity>=9.1.2",
     "typer>=0.16.0",
     "uuid>=1.30",
+    "fastapi>=0.111.0",
 ]
 
 [dependency-groups]
 dev = [
     "pip>=25.1.1",
     "pytest>=8.3.5",
+    "uvicorn>=0.30.0",
 ]
 
 [tool.pytest.ini_options]

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,35 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import uuid
+
+from cli import fill_in_details
+from src.core import Story, Student, StoryCondition
+
+app = FastAPI()
+
+
+class StoryRequest(BaseModel):
+    age: int
+    interests: str
+    situation: str
+    guidance: str | None = None
+
+
+@app.post("/story", response_model=Story)
+def create_story(request: StoryRequest) -> Story:
+    scenario_id = str(uuid.uuid4())
+    student = Student(interests=request.interests, age=request.age)
+    condition = StoryCondition(situation=request.situation, guidance=request.guidance)
+
+    story = Story(
+        scenario_id=scenario_id,
+        student=student,
+        condition=condition,
+    )
+
+    try:
+        fill_in_details(story)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+    return story

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,24 @@
+from fastapi.testclient import TestClient
+
+from src.api import app
+
+
+def test_create_story(monkeypatch):
+    def dummy_fill_in_details(story):
+        story.story_text = "dummy text"
+
+    monkeypatch.setattr("src.api.fill_in_details", dummy_fill_in_details)
+
+    client = TestClient(app)
+    payload = {
+        "age": 8,
+        "interests": "reading",
+        "situation": "needs encouragement",
+        "guidance": "use bright colors",
+    }
+    response = client.post("/story", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["student"]["age"] == 8
+    assert data["story_text"] == "dummy text"
+    assert data["scenario_id"]


### PR DESCRIPTION
## Summary
- add FastAPI application with `/story` endpoint to generate stories
- document API server usage in README
- include fastapi and uvicorn in pyproject dependencies
- test API endpoint with FastAPI TestClient
- make tests import project from repository root

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi and pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68432c7fa8308333b9548e8c2a75481f