### PR TITLE
Add simple frontend and Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+data/
+tests/
+.git/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY . .
+RUN pip install --no-cache-dir --upgrade pip && pip install .
+CMD ["uvicorn", "src.api:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,19 @@ An HTTP API is also available to programmatically create stories.
 uvicorn src.api:app --reload
 ```
 
+The API also serves a small web interface at `/` where you can enter story details.
+
+### Docker
+
+To run on platforms like Railway using Docker:
+
+```bash
+docker build -t storyteller .
+docker run -p 8000:8000 storyteller
+```
+
+Then open `http://localhost:8000` to use the frontend.
+
 ## Target Audience
 
 - **Special Education Teachers**: Primary users who create stories for their students

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "typer>=0.16.0",
     "uuid>=1.30",
     "fastapi>=0.111.0",
+    "uvicorn>=0.30.0",
 ]
 
 [dependency-groups]

--- a/src/api.py
+++ b/src/api.py
@@ -1,11 +1,21 @@
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 import uuid
+import os
 
 from cli import fill_in_details
 from src.core import Story, Student, StoryCondition
 
 app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+
+@app.get("/", include_in_schema=False)
+def index() -> FileResponse:
+    return FileResponse("static/index.html")
 
 
 class StoryRequest(BaseModel):
@@ -33,3 +43,11 @@ def create_story(request: StoryRequest) -> Story:
         raise HTTPException(status_code=500, detail=str(e))
 
     return story
+
+
+@app.get("/story/html/{scenario_id}", response_class=FileResponse)
+def get_story_html(scenario_id: str) -> FileResponse:
+    file_path = os.path.join("data", scenario_id, "story.html")
+    if not os.path.exists(file_path):
+        raise HTTPException(status_code=404, detail="Story not found")
+    return FileResponse(file_path, media_type="text/html")

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Storyteller</title>
+  <style>
+    body { font-family: Arial, sans-serif; max-width: 600px; margin: 40px auto; }
+    label { display: block; margin-top: 10px; }
+    input, textarea { width: 100%; padding: 6px; margin-top: 4px; }
+    button { margin-top: 12px; padding: 8px 16px; }
+  </style>
+</head>
+<body>
+<h1>Create a Story</h1>
+<form id="storyForm">
+  <label>Age
+    <input type="number" id="age" required>
+  </label>
+  <label>Interests
+    <input type="text" id="interests" required>
+  </label>
+  <label>Situation
+    <textarea id="situation" required></textarea>
+  </label>
+  <label>Guidance
+    <input type="text" id="guidance">
+  </label>
+  <button type="submit">Create Story</button>
+</form>
+<button id="viewStory" style="display:none;">View Story</button>
+<script>
+  const form = document.getElementById('storyForm');
+  const viewBtn = document.getElementById('viewStory');
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    viewBtn.style.display = 'none';
+    const payload = {
+      age: Number(document.getElementById('age').value),
+      interests: document.getElementById('interests').value,
+      situation: document.getElementById('situation').value,
+      guidance: document.getElementById('guidance').value
+    };
+    const res = await fetch('/story', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      alert(err.detail || 'Error creating story');
+      return;
+    }
+    const data = await res.json();
+    const url = `/story/html/${data.scenario_id}`;
+    viewBtn.onclick = () => window.open(url, '_blank');
+    viewBtn.style.display = 'inline-block';
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create minimal HTML frontend
- expose HTML from FastAPI app
- serve generated story HTML
- include Dockerfile and dockerignore
- document Docker usage
- add uvicorn to runtime deps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi and pydantic)*

------
https://chatgpt.com/codex/tasks/task_e_68432ef4212c83339a6ff60a5149f6f5