### PR TITLE
Fix event loop errors in async workflow

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -15,7 +15,7 @@ from src.screenplay_writer import create_screenplay
 from src.story_writer import create_story
 from src.utils import deserialize, serialize
 
-assert load_dotenv()
+load_dotenv()
 
 __version__ = "0.0.1"
 

--- a/src/photographer.py
+++ b/src/photographer.py
@@ -1,5 +1,6 @@
 from agents import Agent, ModelSettings, Runner
 from pydantic import BaseModel, Field
+import asyncio
 
 from src.core import Story
 
@@ -35,7 +36,12 @@ def create_scene_descriptions(story: Story) -> SceneDescription:
     Characters: {story.characteristics.characters}, \n\n
     Key Events: {story.characteristics.key_events}"""
 
-    result = Runner.run_sync(photographer_agent, input=input)
+    result = asyncio.run(
+        Runner.run(
+            photographer_agent,
+            input=input,
+        )
+    )
 
     if result.new_items[0].raw_item.status != "completed" or not isinstance(
         result.final_output, SceneDescription

--- a/src/publisher.py
+++ b/src/publisher.py
@@ -43,12 +43,12 @@ def publish_html(story: Story):
         input += f"Scene {scene_id}: {scene}\n"
         input += f"Image URL: {url}\n\n"
 
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        result = Runner.run_sync(publisher_agent, input=input)
-    finally:
-        loop.close()
+    result = asyncio.run(
+        Runner.run(
+            publisher_agent,
+            input=input,
+        )
+    )
 
     if result.new_items[0].raw_item.status != "completed" or not isinstance(
         result.final_output, str

--- a/src/screenplay_writer.py
+++ b/src/screenplay_writer.py
@@ -1,4 +1,5 @@
 from agents import Agent, ModelSettings, Runner
+import asyncio
 
 from src.core import Story, StoryCharacteristics
 
@@ -23,7 +24,12 @@ screenplay_writer_agent = Agent(
 
 def create_screenplay(story: Story) -> StoryCharacteristics:
     print("Creating Screenplay...")
-    result = Runner.run_sync(screenplay_writer_agent, input=story.story_text)
+    result = asyncio.run(
+        Runner.run(
+            screenplay_writer_agent,
+            input=story.story_text,
+        )
+    )
 
     if result.new_items[0].raw_item.status != "completed" or not isinstance(
         result.final_output, StoryCharacteristics

--- a/src/story_writer.py
+++ b/src/story_writer.py
@@ -1,4 +1,5 @@
 from agents import Agent, ModelSettings, Runner
+import asyncio
 
 from src.core import Story
 
@@ -33,7 +34,12 @@ def create_story(story: Story) -> str:
     Interests: {story.student.interests}, 
     Guidance: {story.condition.guidance}"""
 
-    result = Runner.run_sync(story_writer_agent, input=input)
+    result = asyncio.run(
+        Runner.run(
+            story_writer_agent,
+            input=input,
+        )
+    )
 
     return (
         result.final_output


### PR DESCRIPTION
## Summary
- use `asyncio.run` with `Runner.run` instead of `Runner.run_sync`
- call `load_dotenv()` without asserting presence of a .env file
- adjust photographer, publisher, screenplay writer and story writer modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843357a69a48333859a31a812a1f2a3